### PR TITLE
fix: break on *outer* caller and not on callback

### DIFF
--- a/src/metadata/modules_sources.cpp
+++ b/src/metadata/modules_sources.cpp
@@ -176,17 +176,6 @@ namespace
                 result = &(*lower);
                 break;
             }
-            // result was found on previous cycle, check for closest nested method
-            // need it in case of breakpoint setuped at lines without code and before nested method, for example:
-            // {
-            //  <-- breakpoint at line without code (inside method)
-            //     void Method() {...}
-            // }
-            else if (result && lineNum <= (*lower).startLine && (*lower).endLine <= result->endLine)
-            {
-                closestNestedToken = (*lower).methodDef;
-                break;
-            }
             else
                 break;
         }


### PR DESCRIPTION
Info in upstream ticket - https://github.com/Samsung/netcoredbg/issues/124

For example, in this sample -
```c#
await Parallel.ForEachAsync(userHandlers, parallelOptions, async (uri, token) => {
    await new HttpClient().GetAsync("https://google.com");
});
```

Having a breakpoint on the ForEachAsync line would break on the callback func and not on the outer call. This commit fixes that. However, it drops support from what they say in the comment.

Fixes MVP-4337

